### PR TITLE
Wrap range in list function to fix for Python 3

### DIFF
--- a/python/examples/rainbow_blinky.py
+++ b/python/examples/rainbow_blinky.py
@@ -15,7 +15,7 @@ def make_gaussian(fwhm):
 	return gauss
 
 while True:
-	for z in range(1,10)[::-1] + range(1,10):
+	for z in list(range(1, 10)[::-1]) + list(range(1, 10)):
 		fwhm = 5.0/z
 		gauss = make_gaussian(fwhm)
 		for y in range(8):


### PR DESCRIPTION
You can't add `range`s together with `+` in Python 3 as they're `range` objects, not just lists.

`list(range(10))` yields a list so it works in both
