### PR TITLE
fix munmap errors

### DIFF
--- a/python/rpi-ws281x/lib/mailbox.c
+++ b/python/rpi-ws281x/lib/mailbox.c
@@ -74,6 +74,8 @@ void *mapmem(unsigned base, unsigned size)
 
 void *unmapmem(void *addr, unsigned size)
 {
+   unsigned offset = (unsigned)addr % PAGE_SIZE;
+   addr = addr - offset;
    int s = munmap(addr, size);
    if (s != 0) {
       printf("munmap error %d\n", s);


### PR DESCRIPTION
fix unmapmem by taking into account, the memory was requested page aligned, and therefore munmap must be passed the page aligned addresses.