### PR TITLE
fix for IE11 and Windows Phone

### DIFF
--- a/python/examples/unicornpaint/static/unicorn-paint.js
+++ b/python/examples/unicornpaint/static/unicorn-paint.js
@@ -3,6 +3,8 @@ var color = tinycolor('#840000');
 
 $(document).ready(function(){
 
+$.ajaxSetup({ cache: false });
+
 $('.unicorn').draggable({ handle: "h1" });
 
 $(document)


### PR DESCRIPTION
Fix for Issue #19 

The GET requests are being cached in IE.

Turning off ajax caching fixes the problem.