### PR TITLE
Fix build warnings, brightness and trailing whitespace

### DIFF
--- a/c/unicorn/Makefile
+++ b/c/unicorn/Makefile
@@ -1,8 +1,9 @@
 all: lib
-	gcc -Wall unicorn.c -o unicorn -I../../python/rpi-ws281x/lib -L../../python/rpi-ws281x/lib -lm -lws2811 -lpng
+	gcc -Wall unicorn.c -o unicorn -I../../python/rpi-ws281x/lib \
+			-L../../python/rpi-ws281x/lib -lm -lws2811 -lpng
 
 lib:
 	make -C ../../python/rpi-ws281x/lib/ lib
 
 clean:
-	-rm unicorn
+	-rm -f unicorn

--- a/c/unicorn/README.md
+++ b/c/unicorn/README.md
@@ -22,7 +22,7 @@ You can change the animation speed by specifying a delay between frames:
 
     sudo ./unicorn anim/rainbow.png 500
 
-And you can change the brightness by specifying a value between 0 and 100:
+And you can change the brightness by specifying a value between 0 and 255:
 
     sudo ./unicorn anim/rainbow.png 500 1
 
@@ -33,7 +33,7 @@ By default, unicorn will display a swirly rainbow pattern demo.
 
     sudo ./unicorn
 
-You can try different brightnesses by adding them on as a parameter from 0 to 100:
+You can try different brightnesses by adding them on as a parameter from 0 to 255:
 
     sudo ./unicorn 50
 

--- a/c/unicorn/unicorn.c
+++ b/c/unicorn/unicorn.c
@@ -1,4 +1,5 @@
 #include "ws2811.h"
+#include "board_info.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -23,7 +24,7 @@
 
 #define TARGET_FREQ	WS2811_TARGET_FREQ
 #define GPIO_PIN	18
-#define DMA		5
+#define DMA		    5
 
 #define WIDTH		8
 #define HEIGHT		8
@@ -33,7 +34,7 @@ ws2811_t ledstring =
 {
 	.freq = TARGET_FREQ,
 	.dmanum = DMA,
-	.channel = 
+	.channel =
 	{
 		[0] =
 		{
@@ -110,14 +111,14 @@ int anim_delay = 50;
 
 void read_png_file(char* file_name)
 {
-        char header[8];    // 8 is the maximum size that can be checked
-
+        unsigned char header[8];    // 8 is the maximum size that can be checked
         /* open file and test for it being a png */
         FILE *fp = fopen(file_name, "rb");
         if (!fp)
                 abort_("[read_png_file] File %s could not be opened for reading", file_name);
         fread(header, 1, 8, fp);
-        if (png_sig_cmp(header, 0, 8))
+        png_bytep headerbp = header;
+        if (png_sig_cmp(headerbp, 0, 8))
                 abort_("[read_png_file] File %s is not recognized as a PNG file", file_name);
 
 
@@ -190,7 +191,7 @@ void h2rgb(float h, float *r, float *g, float *b){
 
 	// Wrap hue
 	if(h < 0.0 || h > 1.0){
-		h=fabsf(fmodf(h,1.0));	
+		h=fabsf(fmodf(h,1.0));
 	}
 
 	h *= 360.0;
@@ -233,12 +234,12 @@ void h2rgb(float h, float *r, float *g, float *b){
 			*g = p;
 			*b = q;
 			break;
-		
+
 	}
 
 }
 
-void makeRGB(float *r, float *g, float *b, 
+void makeRGB(float *r, float *g, float *b,
 		float f1, float f2, float f3,
 		float p1, float p2, float p3,
 		float c, float w, float pos){
@@ -256,7 +257,7 @@ void transformPixel(float *x, float *y, float angle){
 
 	cs = cos(angle);
 	sn = sin(angle);
-	
+
 	px = *x * cs - *y * sn;
 	py = *x * sn + *y * cs;
 
@@ -274,7 +275,7 @@ void shadePixel(double t, int pixel, float x, float y){
 	angle /= 57.2957795;
 
 	float px, py, cs, sn;
-	
+
 	// Move origin to center
 	x-=0.5;
 	y-=0.5;
@@ -336,7 +337,7 @@ void unicorn_exit(int status){
 	}
 	ws2811_render(&ledstring);
 	ws2811_fini(&ledstring);
-	
+
 	exit(status);
 }
 
@@ -384,7 +385,7 @@ int main(int argc, char **argv) {
 	if(ws2811_init(&ledstring))
 	{
 		return -1;
-	}	
+	}
 
 	clearLEDBuffer();
 
@@ -403,7 +404,7 @@ int main(int argc, char **argv) {
 				break;
 			}
 		}
-	
+
 	}
 
 	unicorn_exit(0);

--- a/c/unicorn/unicorn.c
+++ b/c/unicorn/unicorn.c
@@ -22,13 +22,13 @@
 
 #include <png.h>
 
-#define TARGET_FREQ WS2811_TARGET_FREQ
-#define GPIO_PIN    18
-#define DMA         5
+#define TARGET_FREQ    WS2811_TARGET_FREQ
+#define GPIO_PIN       18
+#define DMA            5
 
-#define WIDTH       8
-#define HEIGHT      8
-#define LED_COUNT   (WIDTH * HEIGHT)
+#define WIDTH          8
+#define HEIGHT         8
+#define LED_COUNT      (WIDTH * HEIGHT)
 
 ws2811_t ledstring =
 {
@@ -46,8 +46,9 @@ ws2811_t ledstring =
     }
 };
 
-void setBrightness(float b)
+void setBrightness(int b)
 {
+    ledstring.channel[0].brightness = b;
     return;
 }
 
@@ -358,12 +359,12 @@ int main(int argc, char **argv) {
             return 0;
 
         }else{
-            setBrightness(newbrightness/100.0);
+            setBrightness(newbrightness);
         }
     }
     if (argc == 2){
         if(sscanf (argv[1], "%i", &newbrightness)==1){
-            setBrightness(newbrightness/100.0);
+            setBrightness(newbrightness);
             shader = 1;
         }
     }

--- a/c/unicorn/unicorn.c
+++ b/c/unicorn/unicorn.c
@@ -22,46 +22,46 @@
 
 #include <png.h>
 
-#define TARGET_FREQ	WS2811_TARGET_FREQ
-#define GPIO_PIN	18
-#define DMA		    5
+#define TARGET_FREQ WS2811_TARGET_FREQ
+#define GPIO_PIN    18
+#define DMA         5
 
-#define WIDTH		8
-#define HEIGHT		8
-#define LED_COUNT	(WIDTH * HEIGHT)
+#define WIDTH       8
+#define HEIGHT      8
+#define LED_COUNT   (WIDTH * HEIGHT)
 
 ws2811_t ledstring =
 {
-	.freq = TARGET_FREQ,
-	.dmanum = DMA,
-	.channel =
-	{
-		[0] =
-		{
-			.gpionum    = GPIO_PIN,
-			.count      = LED_COUNT,
-			.invert     = 0,
-			.brightness = 55,
-		}
-	}
+    .freq = TARGET_FREQ,
+    .dmanum = DMA,
+    .channel =
+    {
+        [0] =
+        {
+            .gpionum    = GPIO_PIN,
+            .count      = LED_COUNT,
+            .invert     = 0,
+            .brightness = 55,
+        }
+    }
 };
 
 void setBrightness(float b)
 {
-	return;
+    return;
 }
 
 void setPixelColorRGB(int pixel, int r, int g, int b)
 {
-	ledstring.channel[0].leds[pixel] = (r << 16) | (g << 8) | b;
-	return;
+    ledstring.channel[0].leds[pixel] = (r << 16) | (g << 8) | b;
+    return;
 }
 
 void clearLEDBuffer(void){
-	int i;
-	for(i=0; i<LED_COUNT;i++){
-		setPixelColorRGB(i,0,0,0);
-	}
+    int i;
+    for(i=0; i<LED_COUNT;i++){
+        setPixelColorRGB(i,0,0,0);
+    }
 }
 
 /*
@@ -69,22 +69,22 @@ void clearLEDBuffer(void){
 */
 int getPixelPosition(int x, int y){
 
-	int map[8][8] = {
-		{7 ,6 ,5 ,4 ,3 ,2 ,1 ,0 },
-		{8 ,9 ,10,11,12,13,14,15},
-		{23,22,21,20,19,18,17,16},
-		{24,25,26,27,28,29,30,31},
-		{39,38,37,36,35,34,33,32},
-		{40,41,42,43,44,45,46,47},
-		{55,54,53,52,51,50,49,48},
-		{56,57,58,59,60,61,62,63}
-	};
+    int map[8][8] = {
+        {7 ,6 ,5 ,4 ,3 ,2 ,1 ,0 },
+        {8 ,9 ,10,11,12,13,14,15},
+        {23,22,21,20,19,18,17,16},
+        {24,25,26,27,28,29,30,31},
+        {39,38,37,36,35,34,33,32},
+        {40,41,42,43,44,45,46,47},
+        {55,54,53,52,51,50,49,48},
+        {56,57,58,59,60,61,62,63}
+    };
 
-	return map[x][y];
+    return map[x][y];
 }
 
 void show(){
-	ws2811_render(&ledstring);
+    ws2811_render(&ledstring);
 }
 
 void abort_(const char * s, ...)
@@ -164,143 +164,143 @@ void read_png_file(char* file_name)
 
 void process_file(void)
 {
-	int currentFrame;
+    int currentFrame;
 
-	for (currentFrame=0; currentFrame<(height/8); currentFrame++){
+    for (currentFrame=0; currentFrame<(height/8); currentFrame++){
         for (y=0; y<8; y++) {
                 png_byte* row = row_pointers[y + (8*currentFrame)];
                 for (x=0; x<width; x++) {
                         png_byte* ptr = &(row[x*3]);
 
-			setPixelColorRGB(getPixelPosition(x,y), ptr[0], ptr[1], ptr[2]);
+            setPixelColorRGB(getPixelPosition(x,y), ptr[0], ptr[1], ptr[2]);
 
                 }
         }
-	show();
-	usleep(anim_delay*1000);
-	}
+    show();
+    usleep(anim_delay*1000);
+    }
 }
 
 void h2rgb(float h, float *r, float *g, float *b){
 
-	int i;
-	float f, p, q, t, s, v;
+    int i;
+    float f, p, q, t, s, v;
 
-	s = 1.0;
-	v = 1.0;
+    s = 1.0;
+    v = 1.0;
 
-	// Wrap hue
-	if(h < 0.0 || h > 1.0){
-		h=fabsf(fmodf(h,1.0));
-	}
+    // Wrap hue
+    if(h < 0.0 || h > 1.0){
+        h=fabsf(fmodf(h,1.0));
+    }
 
-	h *= 360.0;
-	h /= 60.0;
+    h *= 360.0;
+    h /= 60.0;
 
-	i = floor( h );
-	f = h - i;
-	p = (v * ( 1 - s ));
-	q = (v * ( 1 - s * f ));
-	t = (v * ( 1 - s * ( 1 - f ) ));
+    i = floor( h );
+    f = h - i;
+    p = (v * ( 1 - s ));
+    q = (v * ( 1 - s * f ));
+    t = (v * ( 1 - s * ( 1 - f ) ));
 
-	switch( i ){
-		case 0:
-			*r = v;
-			*g = t;
-			*b = p;
-			break;
-		case 1:
-			*r = q;
-			*g = v;
-			*b = p;
-			break;
-		case 2:
-			*r = p;
-			*g = v;
-			*b = t;
-			break;
-		case 3:
-			*r = p;
-			*g = q;
-			*b = v;
-			break;
-		case 4:
-			*r = t;
-			*g = p;
-			*b = v;
-			break;
-		default:
-			*r = v;
-			*g = p;
-			*b = q;
-			break;
+    switch( i ){
+        case 0:
+            *r = v;
+            *g = t;
+            *b = p;
+            break;
+        case 1:
+            *r = q;
+            *g = v;
+            *b = p;
+            break;
+        case 2:
+            *r = p;
+            *g = v;
+            *b = t;
+            break;
+        case 3:
+            *r = p;
+            *g = q;
+            *b = v;
+            break;
+        case 4:
+            *r = t;
+            *g = p;
+            *b = v;
+            break;
+        default:
+            *r = v;
+            *g = p;
+            *b = q;
+            break;
 
-	}
+    }
 
 }
 
 void makeRGB(float *r, float *g, float *b,
-		float f1, float f2, float f3,
-		float p1, float p2, float p3,
-		float c, float w, float pos){
+        float f1, float f2, float f3,
+        float p1, float p2, float p3,
+        float c, float w, float pos){
 
 
-	*r = (( sin(f1 * pos + p1) * w ) + c) / 255;
-	*g = (( sin(f2 * pos + p2) * w ) + c) / 255;
-	*b = (( sin(f3 * pos + p3) * w ) + c) / 255;
+    *r = (( sin(f1 * pos + p1) * w ) + c) / 255;
+    *g = (( sin(f2 * pos + p2) * w ) + c) / 255;
+    *b = (( sin(f3 * pos + p3) * w ) + c) / 255;
 
 }
 
 void transformPixel(float *x, float *y, float angle){
 
-	float px, py, cs, sn;
+    float px, py, cs, sn;
 
-	cs = cos(angle);
-	sn = sin(angle);
+    cs = cos(angle);
+    sn = sin(angle);
 
-	px = *x * cs - *y * sn;
-	py = *x * sn + *y * cs;
+    px = *x * cs - *y * sn;
+    py = *x * sn + *y * cs;
 
-	*x = px;
-	*y = py;
+    *x = px;
+    *y = py;
 }
 
 
 void shadePixel(double t, int pixel, float x, float y){
 
-	float r, g, b;
+    float r, g, b;
 
-	float angle = fmod( (double)(t)/10, (double)360);
+    float angle = fmod( (double)(t)/10, (double)360);
 
-	angle /= 57.2957795;
+    angle /= 57.2957795;
 
-	float px, py, cs, sn;
+    float px, py, cs, sn;
 
-	// Move origin to center
-	x-=0.5;
-	y-=0.5;
+    // Move origin to center
+    x-=0.5;
+    y-=0.5;
 
-	// Pan the X/Y position on a sine wave
-	x+=sin(t/10000.0);
-	y+=sin(y/10000.0);
+    // Pan the X/Y position on a sine wave
+    x+=sin(t/10000.0);
+    y+=sin(y/10000.0);
 
-	// Rotate the pixels
-	cs = cos(angle);
-	sn = sin(angle);
+    // Rotate the pixels
+    cs = cos(angle);
+    sn = sin(angle);
 
-	px = (x * cs) - (y * sn);
-	py = (y * cs) + (x * sn);
+    px = (x * cs) - (y * sn);
+    py = (y * cs) + (x * sn);
 
-	// Convert hue to RGB
-	float hue = (((px+py)/8) + t / 10000.0);
-	h2rgb(hue, &r, &g, &b);
+    // Convert hue to RGB
+    float hue = (((px+py)/8) + t / 10000.0);
+    h2rgb(hue, &r, &g, &b);
 
-	// Clamp max value
-	if(r>1.0) r=1.0;
-	if(g>1.0) g=1.0;
-	if(b>1.0) b=1.0;
+    // Clamp max value
+    if(r>1.0) r=1.0;
+    if(g>1.0) g=1.0;
+    if(b>1.0) b=1.0;
 
-	setPixelColorRGB(pixel, (int)(r*255), (int)(g*255), (int)(b*255));
+    setPixelColorRGB(pixel, (int)(r*255), (int)(g*255), (int)(b*255));
 
 }
 
@@ -310,20 +310,20 @@ void shadePixel(double t, int pixel, float x, float y){
 */
 void run_shader(void){
 
-	struct timeval tv;
-	double t;
-	while(1){
-		gettimeofday(&tv, NULL);
-		t = (tv.tv_sec) * 1000 + (tv.tv_usec) / 1000;
-		for(y=0; y<8; y++){
-			for(x=0; x<8; x++){
-				int pixel = getPixelPosition(x,y);
-				shadePixel(t, pixel, x/7.0, y/7.0);
-			}
-		}
-		show();
-		usleep(1);
-	}
+    struct timeval tv;
+    double t;
+    while(1){
+        gettimeofday(&tv, NULL);
+        t = (tv.tv_sec) * 1000 + (tv.tv_usec) / 1000;
+        for(y=0; y<8; y++){
+            for(x=0; x<8; x++){
+                int pixel = getPixelPosition(x,y);
+                shadePixel(t, pixel, x/7.0, y/7.0);
+            }
+        }
+        show();
+        usleep(1);
+    }
 
 }
 
@@ -331,83 +331,83 @@ void run_shader(void){
   Clear the display and exit gracefully
 */
 void unicorn_exit(int status){
-	int i;
-	for (i = 0; i < 64; i++){
-		setPixelColorRGB(i,0,0,0);
-	}
-	ws2811_render(&ledstring);
-	ws2811_fini(&ledstring);
+    int i;
+    for (i = 0; i < 64; i++){
+        setPixelColorRGB(i,0,0,0);
+    }
+    ws2811_render(&ledstring);
+    ws2811_fini(&ledstring);
 
-	exit(status);
+    exit(status);
 }
 
 int main(int argc, char **argv) {
-	int shader = 0;
+    int shader = 0;
 
-	if (argc >= 3){
-		if(sscanf (argv[2], "%i", &anim_delay)!=1){
-			printf ("Error, delay must be an integer \n");
-			return 0;
-		}
-	}
+    if (argc >= 3){
+        if(sscanf (argv[2], "%i", &anim_delay)!=1){
+            printf ("Error, delay must be an integer \n");
+            return 0;
+        }
+    }
 
-	int newbrightness = 0;
-	if (argc >= 4){
-		if(sscanf (argv[3], "%i", &newbrightness)!=1){
-			printf ("Error, brightness must be an integer \n");
-			return 0;
+    int newbrightness = 0;
+    if (argc >= 4){
+        if(sscanf (argv[3], "%i", &newbrightness)!=1){
+            printf ("Error, brightness must be an integer \n");
+            return 0;
 
-		}else{
-			setBrightness(newbrightness/100.0);
-		}
-	}
- 	if (argc == 2){
-		if(sscanf (argv[1], "%i", &newbrightness)==1){
-			setBrightness(newbrightness/100.0);
-			shader = 1;
-		}
-	}
+        }else{
+            setBrightness(newbrightness/100.0);
+        }
+    }
+    if (argc == 2){
+        if(sscanf (argv[1], "%i", &newbrightness)==1){
+            setBrightness(newbrightness/100.0);
+            shader = 1;
+        }
+    }
 
-	int i;
-	for (i = 0; i < 64; i++) {
-		struct sigaction sa;
-		memset(&sa, 0, sizeof(sa));
-		sa.sa_handler = unicorn_exit;
-		sigaction(i, &sa, NULL);
-	}
+    int i;
+    for (i = 0; i < 64; i++) {
+        struct sigaction sa;
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = unicorn_exit;
+        sigaction(i, &sa, NULL);
+    }
 
-	setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stdout, NULL, _IONBF, 0);
 
-	if (board_info_init() < 0)
-	{
-		return -1;
-	}
-	if(ws2811_init(&ledstring))
-	{
-		return -1;
-	}
+    if (board_info_init() < 0)
+    {
+        return -1;
+    }
+    if(ws2811_init(&ledstring))
+    {
+        return -1;
+    }
 
-	clearLEDBuffer();
+    clearLEDBuffer();
 
-	if(argc < 2){
-		shader = 1;
-	}
+    if(argc < 2){
+        shader = 1;
+    }
 
-	if(shader){
-		run_shader();
-	}else{
+    if(shader){
+        run_shader();
+    }else{
 
-		read_png_file(argv[1]);
-		while(1){
-			process_file();
-			if (height/8 == 1){
-				break;
-			}
-		}
+        read_png_file(argv[1]);
+        while(1){
+            process_file();
+            if (height/8 == 1){
+                break;
+            }
+        }
 
-	}
+    }
 
-	unicorn_exit(0);
+    unicorn_exit(0);
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
### Before ###

```
root@raspberrypi /tmp/work/unicorn-hat/c/unicorn# make
unicorn.c: In function ‘read_png_file’:
unicorn.c:120:9: warning: pointer targets in passing argument 1 of ‘png_sig_cmp’ differ in signedness [-Wpointer-sign]
/usr/include/png.h:1594:8: note: expected ‘png_bytep’ but argument is of type ‘char *’
unicorn.c: In function ‘main’:
unicorn.c:380:2: warning: implicit declaration of function ‘board_info_init’ [-Wimplicit-function-declaration]
[...]
```

### After ###
```
root@raspberrypi /tmp/work/unicorn-hat/c/unicorn # make
make -C ../../python/rpi-ws281x/lib/ lib
make[1]: Entering directory '/tmp/work/unicorn-hat/python/rpi-ws281x/lib'
gcc -o ws2811.o -c -g -O2 -Wall -Werror ws2811.c
gcc -o pwm.o -c -g -O2 -Wall -Werror pwm.c
gcc -o dma.o -c -g -O2 -Wall -Werror dma.c
gcc -o board_info.o -c -g -O2 -Wall -Werror board_info.c
gcc -o mailbox.o -c -g -O2 -Wall -Werror mailbox.c
ar rc libws2811.a ws2811.o pwm.o dma.o board_info.o mailbox.o
ranlib libws2811.a
make[1]: Leaving directory '/tmp/work/unicorn-hat/python/rpi-ws281x/lib'
gcc -Wall unicorn.c -o unicorn -I../../python/rpi-ws281x/lib \
                -L../../python/rpi-ws281x/lib -lm -lws2811 -lpng
```

I don't think the brightness parameter has any effect, i'll look into that too.
Also matrix rotation would be nice. I almost have an improved `getPixelPosition()` that also takes in rotation from command line. Because you guys rock.

EDIT: Brightness now works. Updated README to reflect new integer range.