### PR TITLE
Add Arch Linux ARM support

### DIFF
--- a/c/unicornd/Makefile
+++ b/c/unicornd/Makefile
@@ -11,3 +11,7 @@ install:
 	cp unicornd /usr/sbin
 	cp unicorn /etc/init.d
 	sudo chmod +x /etc/init.d/unicorn
+
+install-archlinux:
+	cp unicornd /usr/sbin
+	cp unicornd.service /etc/systemd/system/

--- a/c/unicornd/README.md
+++ b/c/unicornd/README.md
@@ -8,10 +8,13 @@ user.
 
 It can handle only one connection at a time.
 
-`make install` will install the daemon.
+### Installation
+#### Raspbian
+
+`make install` will install the daemon
 
 ```
-sudo make
+make
 sudo make install
 sudo service unicorn start
 sudo service unicorn stop
@@ -19,7 +22,19 @@ sudo service unicorn stop
 
 To set the daemon to start at boot run `sudo update-rc.d unicorn defaults`
 
-The daemon makes the `pi` user the owner of the `/var/run/unicornd.socket`.
+#### Arch Linux ARM
+
+`make install-archlinux` will install the daemon
+
+```
+make
+su
+make install-archlinux
+systemctl start unicornd
+systemctl stop unicornd
+```
+
+To set the daemon to start at boot run `systemctl enable unicornd`
 
 ### Protocol
 The protocol is simple: each command is composed of a code (the command you want

--- a/c/unicornd/README.md
+++ b/c/unicornd/README.md
@@ -6,7 +6,8 @@ Unicorn Hat daemon is a simple C program that listen on a Unix socket in
 Hat so that you can run the daemon as root and your programs as normal
 user.
 
-It can handle only one connection at a time.
+It can handle only one connection at a time and
+since the socket has `0777` mode every user can connect to the socket.
 
 ### Installation
 #### Raspbian

--- a/c/unicornd/unicorn
+++ b/c/unicornd/unicorn
@@ -22,8 +22,6 @@ case $1 in
 	start)
 		log_daemon_msg "Starting Unicorn Hat server" "unicornd"
   		start-stop-daemon --start -b --quiet --oknodo --pidfile $PIDFILE -m --startas $DAEMON -- $UNICORND_OPTS
-		sleep 1
-		chown pi /var/run/unicornd.socket
 		status=$?
 		log_end_msg $status
   		;;

--- a/c/unicornd/unicornd.c
+++ b/c/unicornd/unicornd.c
@@ -136,6 +136,8 @@ setup_listen_socket(void)
 		exit(1);
 	}
 
+	chmod(SOCK_PATH, 0777);
+
 	ret = listen(listen_socket, 4);
 	if (ret == -1) {
 		fprintf(stderr, "cannot listen on socket");

--- a/c/unicornd/unicornd.service
+++ b/c/unicornd/unicornd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Unicorn HAT daemon
+
+[Service]
+ExecStart=/usr/sbin/unicornd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a Makefile target (`install-archlinux`) to install a systemd service file so that unicornd can be run in a Arch Linux system.
Since in a Arch Linux installation there's no default user (like the `pi` one in Raspbian) I also changed the Unix socket's mode to `0777` so that the service file is not bound to a particular user and everyone can connect to the socket.