### PR TITLE
Add a global library_c Makefile

### DIFF
--- a/library_c/Makefile
+++ b/library_c/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean unicornd unicorn
+
+all: unicornd unicorn
+
+unicornd:
+	make -C unicornd/ unicornd
+
+unicorn:
+	make -C unicorn/ unicorn
+
+clean:
+	make -C unicornd/ clean
+	make -C unicorn/ clean


### PR DESCRIPTION
The Makefile's very basic, but it can be very helpful if someone wants to get both the C unicornd and the example unicorn C client built at the same time.