### PR TITLE
Add support for alternate PWM module (PWM1)

### DIFF
--- a/library/UnicornHat/unicornhat.py
+++ b/library/UnicornHat/unicornhat.py
@@ -10,9 +10,13 @@ LED_PIN        = 18      # GPIO pin connected to the pixels (must support PWM!).
 LED_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
 LED_DMA        = 5       # DMA channel to use for generating signal (try 5)
 LED_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
+LED_CHANNEL    = 0       # PWM channel
 LED_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 
-ws2812 = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS)
+# For PWM0 (default setup) use: CHANNEL 0, PIN 18, DMA 5
+# For PWM1 (requires re-soldering) use: CHANNEL 1, PIN 13, DMA 8
+
+ws2812 = Adafruit_NeoPixel(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
 ws2812.begin()
 
 """

--- a/library_c/unicorn/unicorn.c
+++ b/library_c/unicorn/unicorn.c
@@ -21,7 +21,13 @@
 
 #include "ws2811.h"
 
+/*
+ * For PWM0 (default setup) use CHANNEL 0, GPIO_PIN 18, DMA 5
+ * For PWM1 (requires re-soldering) use CHANNEL 1, GPIO_PIN 13, DMA 8
+ */
+
 #define TARGET_FREQ    WS2811_TARGET_FREQ
+#define CHANNEL        0
 #define GPIO_PIN       18
 #define DMA            5
 
@@ -35,7 +41,7 @@ ws2811_t ledstring =
     .dmanum = DMA,
     .channel =
     {
-        [0] =
+        [CHANNEL] =
         {
             .gpionum    = GPIO_PIN,
             .count      = LED_COUNT,
@@ -47,13 +53,13 @@ ws2811_t ledstring =
 
 void setBrightness(int b)
 {
-    ledstring.channel[0].brightness = b;
+    ledstring.channel[CHANNEL].brightness = b;
     return;
 }
 
 void setPixelColorRGB(int pixel, int r, int g, int b)
 {
-    ledstring.channel[0].leds[pixel] = (r << 16) | (g << 8) | b;
+    ledstring.channel[CHANNEL].leds[pixel] = (r << 16) | (g << 8) | b;
     return;
 }
 


### PR DESCRIPTION
This PR follows a discussion on the Pimoroni forums: http://forums.pimoroni.com/t/unicorn-hat-different-io-then-gpio18/743

The Raspberry Pi has two PWM modules (0 and 1) capable of driving the Unicorn Hat. The hardware is configured to run on PWM0 (GPIO 18), but can run equally well from PWM (GPIO 13). My reason for wanting to do this is that the Pi-DAC+ uses PWM0, which conflicts. By running the Unicorn on PWM1 they can co-exist.

I've made changes to `unicorn.c` and `unicornhat.py` to make it easier to run this with setup. It doesn't change the default behaviour.

Thanks for the support with this @Gadgetoid! 
