### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo pip install unicornhat
 ```
 git clone https://github.com/pimoroni/unicorn-hat
 cd unicorn-hat/
-sudo apt-get install python-dev
+sudo apt-get install python-dev python-setuptools
 cd library/rpi-ws281x
 sudo python setup.py install
 cd ../..


### PR DESCRIPTION
I added the need to install python-setuptools (line 38) because you cannot run python setup.py without setuptools, adding that one package makes the rest of the guide work normally. Tested on default raspbian install.