### PR TITLE
Modifications to add clearing on exit to unicornd

### DIFF
--- a/library_c/unicornd/test_client/client.py
+++ b/library_c/unicornd/test_client/client.py
@@ -16,7 +16,7 @@ def connect():
     global sock
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(UNICORND_SOCKET_PATH)
-    atexit.register(close
+    atexit.register(close)
 
 def set_brightness(val):
     sock.send(struct.pack('=cc',*[chr(UNICORND_CMD_SET_BRIGHTNESS), val]))

--- a/library_c/unicornd/test_client/client.py
+++ b/library_c/unicornd/test_client/client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-import socket, struct
+import socket, struct, atexit
+
 
 UNICORND_SOCKET_PATH        = "/var/run/unicornd.socket"
 
@@ -7,6 +8,7 @@ UNICORND_CMD_SET_BRIGHTNESS = 0
 UNICORND_CMD_SET_PIXEL      = 1
 UNICORND_CMD_SET_ALL_PIXELS = 2
 UNICORND_CMD_SHOW           = 3
+UNICORND_CMD_CLEAR          = 4
 
 sock = None
 
@@ -14,6 +16,7 @@ def connect():
     global sock
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(UNICORND_SOCKET_PATH)
+    atexit.register(close
 
 def set_brightness(val):
     sock.send(struct.pack('=cc',*[chr(UNICORND_CMD_SET_BRIGHTNESS), val]))
@@ -22,10 +25,18 @@ def set_pixel(x,y,r,g,b):
     sock.send(''.join(chr(x) for x in [UNICORND_CMD_SET_PIXEL, x, y, r, g, b]))
 
 def clear():
-    set_all_pixels([0,0,0]*64)
+    sock.send(struct.pack('=c',chr(UNICORND_CMD_CLEAR)))
 
 def set_all_pixels(pixels):
     sock.send(chr(UNICORND_CMD_SET_ALL_PIXELS) + ''.join(chr(x) for x in pixels))
 
 def show():
     sock.send(struct.pack('=c',chr(UNICORND_CMD_SHOW)))
+
+def close():
+    global sock
+    if sock:
+        clear()
+        show()
+        sock.close()
+        sock = None

--- a/library_c/unicornd/unicornd.c
+++ b/library_c/unicornd/unicornd.c
@@ -146,6 +146,7 @@ init_unicorn_hat(void)
 #define	UNICORND_CMD_SET_PIXEL      1
 #define	UNICORND_CMD_SET_ALL_PIXELS 2
 #define	UNICORND_CMD_SHOW           3
+#define	UNICORND_CMD_CLEAR          4
 
 #define recv_or_return(socket, buf, len, flags) \
 {                                               \
@@ -275,6 +276,11 @@ handle_client(int client_socket) {
 				show();
 				break;
 
+			case UNICORND_CMD_CLEAR:
+
+				clear_led_buffer();
+				break;
+				
 			default:
 
 				close(client_socket);


### PR DESCRIPTION
I'm not sure how much unicornd is used – I use it so my students don't need to use sudo when communicating with the Unicorn PHAT...

This PR adds a CLEAR-command to unicornd and adds this to test_client/client.py. Also clearing of the led-panel and cleaning up has been added with atexit.register so the panel isn't left with the leds on.
