### PR TITLE
Various fixes for the C library

### DIFF
--- a/library_c/unicorn/Makefile
+++ b/library_c/unicorn/Makefile
@@ -1,13 +1,15 @@
-.PHONY: clean lib
+.PHONY: all clean
+
+ws281x_path = ../unicornd/rpi_ws281x
 
 all: unicorn
 
-lib:
-	make -C ../../library/rpi-ws281x/lib/ lib
+$(ws281x_path)/libws2811.a:
+	scons -C $(ws281x_path)
 
-unicorn: lib
-	gcc -Wall unicorn.c -o unicorn -I../../library/rpi-ws281x/lib -L../../library/rpi-ws281x/lib -lm -lws2811 -lpng
+unicorn: $(ws281x_path)/libws2811.a unicorn.c
+	gcc -Wall unicorn.c -o unicorn -I$(ws281x_path) -L$(ws281x_path) -lm -lws2811 -lpng
 
 clean:
-	make -C ../../library/rpi-ws281x/lib/ clean
+	scons -C $(ws281x_path) --clean
 	-rm -f unicorn

--- a/library_c/unicorn/unicorn.c
+++ b/library_c/unicorn/unicorn.c
@@ -41,6 +41,7 @@ ws2811_t ledstring =
             .count      = LED_COUNT,
             .invert     = 0,
             .brightness = 55,
+            .strip_type = WS2811_STRIP_GRB,
         }
     }
 };

--- a/library_c/unicorn/unicorn.c
+++ b/library_c/unicorn/unicorn.c
@@ -368,12 +368,39 @@ int main(int argc, char **argv) {
         }
     }
 
+    /* All terminating signals, as described by 'man 7 signal'. */
+    static const int term_signals[] = {
+        /* POSIX.1-1990 */
+        SIGHUP,
+        SIGINT,
+        SIGQUIT,
+        SIGILL,
+        SIGABRT,
+        SIGFPE,
+        SIGKILL,
+        SIGSEGV,
+        SIGPIPE,
+        SIGALRM,
+        SIGTERM,
+        SIGUSR1,
+        SIGUSR2,
+        /* POSIX.1-2001 */
+        SIGBUS,
+        SIGPOLL,
+        SIGPROF,
+        SIGSYS,
+        SIGTRAP,
+        SIGVTALRM,
+        SIGXCPU,
+        SIGXFSZ,
+    };
+
     int i;
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < sizeof(term_signals)/sizeof(term_signals[0]); i++) {
         struct sigaction sa;
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = unicorn_exit;
-        sigaction(i, &sa, NULL);
+        sigaction(term_signals[i], &sa, NULL);
     }
 
     setvbuf(stdout, NULL, _IONBF, 0);

--- a/library_c/unicornd/Makefile
+++ b/library_c/unicornd/Makefile
@@ -1,11 +1,17 @@
-.PHONY: clean lib install install-archlinux
+.PHONY: all clean install install-archlinux
+
+ws281x_path = rpi_ws281x
 
 all: unicornd
 
-unicornd:
-	gcc -Wall unicornd.c -o unicornd -Irpi_ws281x -Lrpi_ws281x -lws2811
+$(ws281x_path)/libws2811.a:
+	scons -C $(ws281x_path)
+
+unicornd: unicornd.c $(ws281x_path)/libws2811.a
+	gcc -Wall unicornd.c -o unicornd -I$(ws281x_path) -L$(ws281x_path) -lws2811
 
 clean:
+	scons -C $(ws281x_path) --clean
 	-rm -f unicornd
 
 install:

--- a/library_c/unicornd/unicornd.c
+++ b/library_c/unicornd/unicornd.c
@@ -51,6 +51,7 @@ ws2811_t ledstring =
             .count      = LED_COUNT,
             .invert     = 0,
             .brightness = 55,
+            .strip_type = WS2811_STRIP_GRB,
         }
     }
 };

--- a/library_c/unicornd/unicornd.c
+++ b/library_c/unicornd/unicornd.c
@@ -123,11 +123,37 @@ init_unicorn_hat(void)
 {
 	int i;
 	struct sigaction sa;
+	/* All terminating signals, as described by 'man 7 signal'. */
+	static const int term_signals[] = {
+		/* POSIX.1-1990 */
+		SIGHUP,
+		SIGINT,
+		SIGQUIT,
+		SIGILL,
+		SIGABRT,
+		SIGFPE,
+		SIGKILL,
+		SIGSEGV,
+		SIGPIPE,
+		SIGALRM,
+		SIGTERM,
+		SIGUSR1,
+		SIGUSR2,
+		/* POSIX.1-2001 */
+		SIGBUS,
+		SIGPOLL,
+		SIGPROF,
+		SIGSYS,
+		SIGTRAP,
+		SIGVTALRM,
+		SIGXCPU,
+		SIGXFSZ,
+	};
 
-	for (i = 0; i < 64; i++) {
+	for (i = 0; i < sizeof(term_signals)/sizeof(term_signals[0]); i++) {
 		memset(&sa, 0, sizeof(sa));
 		sa.sa_handler = unicornd_exit;
-		sigaction(i, &sa, NULL);
+		sigaction(term_signals[i], &sa, NULL);
 	}
 
 	setvbuf(stdout, NULL, _IONBF, 0);


### PR DESCRIPTION
Hello,

I've got a few patches that fix the C library and example client. The changes are independent, so I can split them into separate pull requests if you like. (I'm not sure of the etiquette here.) The actual changes are described in the commit messages.

As I understand #136, files under `library_c/unicornd/` are currently licensed as GPLv2. There is a pull request (#137) changing the licence of `unicornd` to MIT, but it's not merged to master yet. My contributions to `unicornd` are therefore under the GPLv2 licence, but under the assumption that #137 will merge at some point, you have my permission to relicense these contributions as MIT. My intention is to decouple my pull request from #137.

My contributions to `library_c/unicorn/` are licensed as MIT (as per the top-level `LICENSE` file) and are not affected by #137.

Thanks!
Jacob